### PR TITLE
Expose "dispose" cleanup method in AutoImport

### DIFF
--- a/src/auto-complete/index.ts
+++ b/src/auto-complete/index.ts
@@ -14,6 +14,7 @@ export interface Options {
 class AutoImport {
   private readonly editor: Monaco.editor.IStandaloneCodeEditor
   public imports = new ImportDb()
+  private disposables: Monaco.IDisposable[]
 
   constructor(options: Options) {
     monaco = options.monaco
@@ -26,13 +27,19 @@ class AutoImport {
    * Register the commands to monaco & enable auto-importation
    */
   public attachCommands() {
+    this.disposables = new Array<Monaco.IDisposable>();
+
     const completor = new ImportCompletion(monaco, this.editor, this.imports)
-    monaco.languages.registerCompletionItemProvider('javascript', completor)
-    monaco.languages.registerCompletionItemProvider('typescript', completor)
+    this.disposables.push(monaco.languages.registerCompletionItemProvider('javascript', completor))
+    this.disposables.push(monaco.languages.registerCompletionItemProvider('typescript', completor))
 
     const actions = new ImportAction(this.editor, this.imports)
-    monaco.languages.registerCodeActionProvider('javascript', actions as any)
-    monaco.languages.registerCodeActionProvider('typescript', actions as any)
+    this.disposables.push(monaco.languages.registerCodeActionProvider('javascript', actions as any))
+    this.disposables.push(monaco.languages.registerCodeActionProvider('typescript', actions as any))
+  }
+
+  public dispose() {
+    this.disposables.forEach(disposable => disposable.dispose())
   }
 }
 


### PR DESCRIPTION
## Summary

In multi-editor environments, we need the ability to dispose of registered providers. Otherwise, you'll get a forever trail of imports.